### PR TITLE
Foundry v12 version bump + minor changes.

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,7 +14,7 @@
     "compatibility": {
         "minimum": "10",
         "verified": "11",
-        "maximum": "11"
+        "maximum": "12"
     },
     "compatibleCoreVersion": "11",
     "download": "https://github.com/Tronikart/proper-pixels/releases/latest/download/module.zip",

--- a/scripts/pixel-token.js
+++ b/scripts/pixel-token.js
@@ -37,7 +37,7 @@ Hooks.on("canvasReady", () => {
     }
     if (getAffectTiles()) {
         // there has to be an easier way to get tiles, right?
-        for (let tile of canvas.layers[4].children[0].children) {
+        for (let tile of canvas.tiles.children[0].children) {
             tile.texture.baseTexture.setStyle(0,0);
             tile.texture.baseTexture.update();
         }
@@ -49,19 +49,16 @@ Hooks.on("createToken",  async (token) => {
     // if you know a less-hacky way to do this, please feel free to send a PR
     if (getAffectTokens()) {
         await new Promise(resolve => setTimeout(resolve, 100));
-        var baseTexture = token.object.texture.baseTexture;
+        const baseTexture = token.object.texture.baseTexture;
         baseTexture.setStyle(0,0);
         baseTexture.update();
     }
 })
 
-Hooks.on("updateToken", async (token) => {
-    // await is my hammer for all these nails
+Hooks.on("preUpdateToken", (token) => {
     if (getAffectTokens()) {
-        await new Promise(resolve => setTimeout(resolve, 250));
-        var baseTexture = token.object.texture.baseTexture
+        const baseTexture = token.object.texture.baseTexture;
         baseTexture.setStyle(0,0);
-        baseTexture.update();
     }
 })
 
@@ -69,17 +66,15 @@ Hooks.on("createTile",  async (tile) => {
     // you know the drill
     if (getAffectTiles()) {
         await new Promise(resolve => setTimeout(resolve, 100));
-        var baseTexture = tile.object.texture.baseTexture;
+        const baseTexture = tile.object.texture.baseTexture;
         baseTexture.setStyle(0,0);
         baseTexture.update();
     }
 })
 
-Hooks.on("updateTile", async (tile) => {
-    await new Promise(resolve => setTimeout(resolve, 250));
+Hooks.on("preUpdateTile", (tile) => {
     if (getAffectTiles()) {
-        var baseTexture = tile.object.texture.baseTexture;
+        const baseTexture = tile.object.texture.baseTexture;
         baseTexture.setStyle(0,0);
-        baseTexture.update();
     }
 })


### PR DESCRIPTION
I adjusted module.json to maximum foundry version 12 and made a few changes to the code:
- how the canvas tiles are being fetched on canvasReady.
- changed var declarations to const (no need for var).
- switched update hooks to preUpdate variants, no need for the async await dance there as we adjust the basetexture style before it continues to the regular update routine. I did not observe any ill effects from that, regular update seems not to override the changes made to the tile/token.