### PR TITLE
v13 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,7 +14,7 @@
     "compatibility": {
         "minimum": "10",
         "verified": "11",
-        "maximum": "12"
+        "maximum": "13"
     },
     "compatibleCoreVersion": "11",
     "download": "https://github.com/Tronikart/proper-pixels/releases/latest/download/module.zip",

--- a/scripts/pixel-token.js
+++ b/scripts/pixel-token.js
@@ -4,7 +4,7 @@ export function getAffectCharacterSheets() { return game.settings.get('proper-pi
 export function getIgnoreTag() { return game.settings.get('proper-pixels', 'tokenTag') };
 export function getShouldIgnorePreTaggerReady(token) {
     const tags = token.document?.flags?.tagger?.tags;
-    return game.modules.get('tagger')?.active && tags != null && (tags.find(t => t === getIgnoreTag()) != null)
+    return game.modules.get('tagger')?.active && tags != null && tags.length > 0 && (tags.find(t => t === getIgnoreTag()) != null);
 };
 
 
@@ -103,6 +103,7 @@ Hooks.on("preUpdateToken", (token) => {
         baseTexture.setStyle(0, 0);
     }
 })
+
 
 Hooks.on("createTile", async (tile) => {
     // you know the drill


### PR DESCRIPTION
Bumps module.json package compatibility, and implements #11 
This preserves v12 support

<table>
<tr>
<td><img width="300" src="https://github.com/user-attachments/assets/79b8fef8-8b81-4a16-b8e1-40aed2e7a2c3" /></td>
<td><img width="300" src="https://github.com/user-attachments/assets/17345a4e-7965-492d-abe8-a51ab71e6f35" /></td>
</tr>
<tr>
<td><p align="center">Before</p></td>
<td><p align="center">After</p></td>
</tr>
</table>